### PR TITLE
Added float support for delay in AioPikaBroker

### DIFF
--- a/taskiq_aio_pika/broker.py
+++ b/taskiq_aio_pika/broker.py
@@ -250,7 +250,7 @@ class AioPikaBroker(AsyncBroker):
             ),
         }
 
-        delay: Optional[int] = parse_val(int, message.labels.get("delay"))
+        delay: Optional[float] = parse_val(float, message.labels.get("delay"))
         rmq_message: Message = Message(**message_base_params)
 
         if delay is None:
@@ -260,7 +260,7 @@ class AioPikaBroker(AsyncBroker):
             )
             await exchange.publish(rmq_message, routing_key=message.task_name)
         elif self._delayed_message_exchange_plugin:
-            rmq_message.headers["x-delay"] = delay * 1000
+            rmq_message.headers["x-delay"] = int(delay * 1000)
             exchange = await self.write_channel.get_exchange(
                 self._delay_plugin_exchange_name,
             )


### PR DESCRIPTION
Why:

Some use cases require short delays (less than 1 second), which were previously unsupported due to integer-only handling. This change enables more precise control over task delays.

delay Handling:

I deliberately chose not to infer the delay type from labels types.
The delay value is now always and explicitly cast to float, regardless of the original label type.
This enforces strict and predictable behavior, eliminating ambiguity.
